### PR TITLE
Change to RPC calls to support Litecoin and older clients 

### DIFF
--- a/2_accept_offer.py
+++ b/2_accept_offer.py
@@ -179,7 +179,8 @@ for message in r.get_messages():
   try:
     response = process_offer(offer, audit)
   except socket.error as err:
-    print "Could not connect to wallet."
+    
+    print "Could not connect to wallet:"+str(err)
     sys.exit(1)
   if not response:
     break

--- a/cate/blockchain.py
+++ b/cate/blockchain.py
@@ -51,13 +51,20 @@ def get_first_block(proxy, not_before_time):
   sent at the given time.
 
   Returns a tuple of block height and the first block
-  """
-  blockchain_info = proxy.getblockchaininfo()
 
+  """
+  try:
+    # introduced in Bitcoin Core v 0.9.2  
+    blockchain_info = proxy.getblockchaininfo()
+    height= blockchain_info['blocks']
+    bestblockhash= lx(blockchain_info['bestblockhash'])
+  except bitcoin.rpc.JSONRPCException as e:
+    height=proxy.getblockcount()
+    bestblockhash=proxy.getblockhash(height)
+    
   # Figure out approximate block interval by grabbing the last block, and ten blocks ago
-  height = blockchain_info['blocks']
   prev_height = max(0, height - 10)
-  block_top = proxy.getblock(lx(blockchain_info['bestblockhash']))
+  block_top = proxy.getblock(bestblockhash)
   block_prev = proxy.getblock(proxy.getblockhash(prev_height))
 
   if block_top.nTime > not_before_time:

--- a/cate/tx.py
+++ b/cate/tx.py
@@ -115,7 +115,11 @@ def build_send_transaction(proxy, quantity, sender_public_key, recipient_public_
   # Generate a change transaction if needed
   if total_in > quantity_inc_fee:
     change = total_in - quantity_inc_fee
-    change_address = proxy.getrawchangeaddress()
+    try:
+        # getrawchangeaddress was introduced v0.9 
+        change_address = proxy.getrawchangeaddress()
+    except bitcoin.rpc.JSONRPCException as e:
+        change_address = proxy.getnewaddress()
     change_txout = CTxOut(change, change_address.to_scriptPubKey())
     txouts.append(change_txout)
 


### PR DESCRIPTION
Changes so RPC calls will work with clients without support for getrawchangeaddress and getblockchaininfo. This will work with Litecoin core's current stable release (v0.8.7.5)
