### PR TITLE
Put win32 and datadir logic in it's own classes

### DIFF
--- a/src/main/java/org/libdohj/cate/CATE.java
+++ b/src/main/java/org/libdohj/cate/CATE.java
@@ -18,19 +18,6 @@ package org.libdohj.cate;
 import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.sun.jna.Library;
-import com.sun.jna.Native;
-import com.sun.jna.NativeMapped;
-import com.sun.jna.PointerType;
-import com.sun.jna.platform.win32.Guid;
-import com.sun.jna.platform.win32.Ole32;
-import com.sun.jna.ptr.PointerByReference;
-import com.sun.jna.win32.StdCallLibrary;
-import com.sun.jna.win32.W32APIFunctionMapper;
-import com.sun.jna.win32.W32APITypeMapper;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
@@ -38,6 +25,7 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 
 import org.libdohj.cate.controller.MainController;
+import org.libdohj.cate.util.DataDirFactory;
 
 /**
  * CATE: Cross-chain Atomic Trading Engine
@@ -47,56 +35,16 @@ import org.libdohj.cate.controller.MainController;
 public class CATE extends Application {
     private static final String APPLICATION_NAME_FOLDER = "CATE";
     private static Logger logger  = Logger.getLogger(CATE.class.getName());
-    private static File dataDir;
+    private static final DataDirFactory dataDirFactory = new DataDirFactory(APPLICATION_NAME_FOLDER);
 
-    private static File buildDataDir() {
-        if (com.sun.jna.Platform.isWindows()) {
-            // Modified from http://stackoverflow.com/questions/5953149/detect-the-location-of-appdata-locallow-with-jna
-            final PointerByReference ppszPath = new PointerByReference();
-            int hResult = Shell32.INSTANCE.SHGetKnownFolderPath(Shell32.FOLDERID_RoamingAppData,
-                Shell32.KF_FLAG_CREATE, (HANDLE) null, ppszPath);
-            if (Shell32.S_OK == hResult) {
-                try {
-                    String path = nullTerminatedToString(ppszPath);
-
-                    return new File(path + "\\" + APPLICATION_NAME_FOLDER);
-                } finally {
-                    Ole32.INSTANCE.CoTaskMemFree(ppszPath.getValue());
-                }
-            } else {
-                logger.log(Level.SEVERE, null, "Could not determine local application data directory: " + hResult);
-            }
-        } else if (com.sun.jna.Platform.isMac()) {
-            // As per https://developer.apple.com/library/mac/qa/qa1170/_index.html
-            return new File(System.getProperty("user.home") + "/Library/" + APPLICATION_NAME_FOLDER);
-        }
-        return new File(System.getProperty("user.home") + "/." + APPLICATION_NAME_FOLDER.toLowerCase());
-    }
+    private static File dataDir = null;
 
     /**
      * @return the dataDir
      */
     public static File getDataDir() {
+        // TODO decouple me
         return dataDir;
-    }
-
-    /**
-     * Convert a Win32 string into a Java string.
-     *
-     * @param ppszPath pointer to the string to convert.
-     */
-    private static String nullTerminatedToString(PointerByReference ppszPath) {
-        char delim = '\0';
-        char[] chars = ppszPath.getValue().getCharArray(0, Shell32.MAX_PATH);
-        int charIdx;
-
-        for (charIdx = 0; charIdx < chars.length; charIdx++) {
-            if (chars[charIdx] == delim) {
-                break;
-            }
-        }
-
-        return new String(chars, 0, charIdx);
     }
 
     private MainController controller;
@@ -119,42 +67,13 @@ public class CATE extends Application {
     }
 
     public static void main(String[] args) {
-        dataDir = buildDataDir();
-
-        if (!dataDir.exists()) {
-            dataDir.mkdir();
+        try {
+            dataDir = dataDirFactory.get();
+        } catch (DataDirFactory.UnableToDetermineDataDirException ex) {
+            logger.log(Level.SEVERE, "Unable to determine path to Data Directory", ex);
         }
 
         launch(args);
     }
 
-    private static final Map<String, Object> LOAD_LIBRARY_OPTIONS = new HashMap<>();
-    static {
-        LOAD_LIBRARY_OPTIONS.put(Library.OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
-        LOAD_LIBRARY_OPTIONS.put(Library.OPTION_FUNCTION_MAPPER, W32APIFunctionMapper.UNICODE);
-    }
-
-    static class HANDLE extends PointerType implements NativeMapped {
-    }
-
-    /**
-     * Wrapper around the Windows Shell32 library, used to get the path of the
-     * application data folder.
-     */
-    static interface Shell32 extends StdCallLibrary {
-
-        public static final int MAX_PATH = 260;
-        public static final Guid.GUID FOLDERID_RoamingAppData = new Guid.GUID("3EB685DB-65F9-4CF6-A03A-E3EF65729F3D");
-        public static final int KF_FLAG_CREATE = 0x00008000;
-        public static final int S_OK = 0;
-
-        static Shell32 INSTANCE = (Shell32) Native.loadLibrary("shell32", Shell32.class, LOAD_LIBRARY_OPTIONS);
-
-        /**
-         * See https://msdn.microsoft.com/en-us/library/bb762188(v=vs.85).aspx
-         */
-        public int SHGetKnownFolderPath(Guid.GUID hwndOwner, int dwFlags, HANDLE hToken,
-                PointerByReference ppszPath);
-
-    }
 }

--- a/src/main/java/org/libdohj/cate/util/DataDirFactory.java
+++ b/src/main/java/org/libdohj/cate/util/DataDirFactory.java
@@ -1,0 +1,68 @@
+package org.libdohj.cate.util;
+
+import java.io.File;
+
+/**
+ * Determines datadir based on host OS
+ */
+public class DataDirFactory {
+
+    //TODO might want to make this more generic & extract it
+    public class UnableToDetermineDataDirException extends Exception {
+        public UnableToDetermineDataDirException(String message) {
+            super(message);
+        }
+    }
+
+    private final String applicationNameFolder;
+    private File dataDir = null;
+
+    public DataDirFactory(String applicationNameFolder) {
+        this.applicationNameFolder = applicationNameFolder;
+    }
+
+    /**
+     * Get the dataDir and build it if it is undefined.
+     * @return File describing the datadir.
+     * @throws UnableToDetermineDataDirException
+     */
+    public File get() throws UnableToDetermineDataDirException {
+        if (dataDir == null) build();
+        return dataDir;
+    }
+
+    /**
+     * Defines and creates a dataDir if it does not exist
+     * @return File the dataDir
+     * @throws UnableToDetermineDataDirException
+     */
+    public File build() throws UnableToDetermineDataDirException {
+        String path = constructPath();
+
+        //TODO make this a Exception so that we can gracefully shutdown and perhaps inform the user :D
+        if (path == null)
+            throw new UnableToDetermineDataDirException("Unable to determine appData Directory");
+
+        dataDir = new File(path);
+
+        if (!dataDir.exists())
+            dataDir.mkdir();
+
+        return dataDir;
+    }
+
+    /**
+     * Constructs the path depending on which OS is detected by JNA
+     * @return String pointing to the absolute path of our application data folder
+     */
+    private String constructPath() {
+        if (com.sun.jna.Platform.isWindows()) {
+            return Win32Utils.determineAppDataDir() + "\\" + applicationNameFolder;
+        } else if (com.sun.jna.Platform.isMac()) {
+            // As per https://developer.apple.com/library/mac/qa/qa1170/_index.html
+            return System.getProperty("user.home") + "/Library/" + applicationNameFolder;
+        }
+        // assume LINUX/BSD
+        return System.getProperty("user.home") + "/." + applicationNameFolder.toLowerCase();
+    }
+}

--- a/src/main/java/org/libdohj/cate/util/Win32Utils.java
+++ b/src/main/java/org/libdohj/cate/util/Win32Utils.java
@@ -1,0 +1,99 @@
+package org.libdohj.cate.util;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeMapped;
+import com.sun.jna.PointerType;
+import com.sun.jna.platform.win32.Guid;
+import com.sun.jna.platform.win32.Ole32;
+import com.sun.jna.ptr.PointerByReference;
+import com.sun.jna.win32.StdCallLibrary;
+import com.sun.jna.win32.W32APIFunctionMapper;
+import com.sun.jna.win32.W32APITypeMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// Convenience functions that interface with Windows' Shell32 Lib
+public class Win32Utils {
+
+    private static Logger logger  = Logger.getLogger(Win32Utils.class.getName());
+
+    /**
+     * Determines the location of the AppData/Roaming folder
+     */
+    public static String determineAppDataDir()
+    {
+        String appDataDir = null;
+
+        // Modified from http://stackoverflow.com/questions/5953149/detect-the-location-of-appdata-locallow-with-jna
+        final PointerByReference ppszPath = new PointerByReference();
+
+        int hResult = Shell32.INSTANCE.SHGetKnownFolderPath(
+                Shell32.FOLDERID_RoamingAppData,
+                Shell32.KF_FLAG_CREATE, null, ppszPath);
+
+        if (Shell32.S_OK == hResult) {
+            try {
+                appDataDir = nullTerminatedToString(ppszPath);
+            } finally {
+                Ole32.INSTANCE.CoTaskMemFree(ppszPath.getValue());
+            }
+        } else {
+            logger.log(Level.SEVERE, null, "Could not determine local application data directory: " + hResult);
+        }
+
+        return appDataDir;
+    }
+    /**
+     * Convert a Win32 string into a Java string.
+     *
+     * @param ppszPath pointer to the string to convert.
+     */
+    public static String nullTerminatedToString(PointerByReference ppszPath) {
+        char delim = '\0';
+        char[] chars = ppszPath.getValue().getCharArray(0, Shell32.MAX_PATH);
+        int charIdx;
+
+        for (charIdx = 0; charIdx < chars.length; charIdx++) {
+            if (chars[charIdx] == delim) {
+                break;
+            }
+        }
+
+        return new String(chars, 0, charIdx);
+    }
+
+    private static final Map<String, Object> LOAD_LIBRARY_OPTIONS = new HashMap<>();
+    static {
+        LOAD_LIBRARY_OPTIONS.put(Library.OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
+        LOAD_LIBRARY_OPTIONS.put(Library.OPTION_FUNCTION_MAPPER, W32APIFunctionMapper.UNICODE);
+    }
+
+
+    static class HANDLE extends PointerType implements NativeMapped {}
+
+    /**
+     * Wrapper around the Windows Shell32 library, used to get the path of the
+     * application data folder.
+     */
+     public interface Shell32 extends StdCallLibrary {
+
+        int MAX_PATH = 260;
+        Guid.GUID FOLDERID_RoamingAppData = new Guid.GUID("3EB685DB-65F9-4CF6-A03A-E3EF65729F3D");
+        int KF_FLAG_CREATE = 0x00008000;
+        int S_OK = 0;
+
+        Shell32 INSTANCE = (Shell32) Native.loadLibrary("shell32", Shell32.class, LOAD_LIBRARY_OPTIONS);
+
+        /**
+         * See https://msdn.microsoft.com/en-us/library/bb762188(v=vs.85).aspx
+         */
+        int SHGetKnownFolderPath(Guid.GUID hwndOwner, int dwFlags, HANDLE hToken,
+                                        PointerByReference ppszPath);
+
+    }
+
+}


### PR DESCRIPTION
Extracts all the Shell32 code into Win32Utils and introduces a DataDirFactory that contains OS-specific determination of which path the data directory should be in.
