### PR TITLE
Decouple networks and datadirs from MainController

### DIFF
--- a/src/main/java/org/libdohj/cate/CATE.java
+++ b/src/main/java/org/libdohj/cate/CATE.java
@@ -39,14 +39,6 @@ public class CATE extends Application {
 
     private static File dataDir = null;
 
-    /**
-     * @return the dataDir
-     */
-    public static File getDataDir() {
-        // TODO decouple me
-        return dataDir;
-    }
-
     private MainController controller;
 
     @Override
@@ -55,6 +47,9 @@ public class CATE extends Application {
         Parent root = loader.load();
 
         this.controller = (MainController) loader.getController();
+
+        this.controller.connectTo("Dogecoin", dataDir);
+        this.controller.connectTo("Dogecoin test", dataDir);
 
         primaryStage.setTitle("CATE");
         primaryStage.setScene(new Scene(root, 800, 500));
@@ -71,6 +66,7 @@ public class CATE extends Application {
             dataDir = dataDirFactory.get();
         } catch (DataDirFactory.UnableToDetermineDataDirException ex) {
             logger.log(Level.SEVERE, "Unable to determine path to Data Directory", ex);
+            System.exit(1);
         }
 
         launch(args);

--- a/src/main/java/org/libdohj/cate/NetworkResolver.java
+++ b/src/main/java/org/libdohj/cate/NetworkResolver.java
@@ -1,0 +1,39 @@
+package org.libdohj.cate;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.params.MainNetParams;
+import org.bitcoinj.params.TestNet3Params;
+import org.libdohj.params.DogecoinMainNetParams;
+import org.libdohj.params.DogecoinTestNet3Params;
+import org.libdohj.params.LitecoinMainNetParams;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Resolves NetworkParameters into names and names into NetworkParameters
+ */
+public class NetworkResolver {
+    private static final LinkedHashMap<NetworkParameters, String> networkNames = new LinkedHashMap<>();
+    private static final LinkedHashMap<String, NetworkParameters> networksByName = new LinkedHashMap<>();
+
+    static {
+        // TODO: Localize
+        networkNames.put(MainNetParams.get(), "Bitcoin");
+        networkNames.put(TestNet3Params.get(), "Bitcoin test");
+        networkNames.put(LitecoinMainNetParams.get(), "Litecoin");
+        networkNames.put(DogecoinMainNetParams.get(), "Dogecoin");
+        networkNames.put(DogecoinTestNet3Params.get(), "Dogecoin test");
+
+        for (NetworkParameters params: networkNames.keySet()) {
+            networksByName.put(networkNames.get(params), params);
+        }
+    }
+
+    public static String getName(NetworkParameters params) {
+        return networkNames.get(params);
+    }
+
+    public static NetworkParameters getParams(String name) {
+        return networksByName.get(name);
+    }
+}


### PR DESCRIPTION
- Move network/name resolution to it's own class
- Add `connectTo()` public method to MainController to enable injecting networks (needed if you want to have configurable networks)
- Remove the dependency on `CATE` inside MainController (was only for datadirs)
- For now, still just use 2 hardcoded networks, but define them in the main class rather than in the controller.
