### PR TITLE
Add a link to a blockexplorer

### DIFF
--- a/src/main/java/org/libdohj/cate/CATE.java
+++ b/src/main/java/org/libdohj/cate/CATE.java
@@ -15,10 +15,8 @@
  */
 package org.libdohj.cate;
 
-import com.google.common.util.concurrent.Service;
 import java.io.File;
 import java.util.ResourceBundle;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -42,6 +40,8 @@ import org.libdohj.cate.util.NetworkResolver;
  */
 public class CATE extends Application {
 
+    private static CATE instance;
+
     private static final String APPLICATION_NAME_FOLDER = "CATE";
     private static Logger logger = Logger.getLogger(CATE.class.getName());
     private static final DataDirFactory dataDirFactory = new DataDirFactory(APPLICATION_NAME_FOLDER);
@@ -50,6 +50,18 @@ public class CATE extends Application {
 
     private MainController controller;
     private ExecutorService listenerExecutor = Executors.newSingleThreadExecutor();
+
+    public CATE() {
+        instance = this;
+    }
+
+    /**
+     * Get the current Application instance
+     * @return The current Application/CATE instance
+     */
+    public static CATE getInstance() {
+        return instance;
+    }
 
     @Override
     public void start(Stage primaryStage) throws Exception {

--- a/src/main/java/org/libdohj/cate/controller/MainController.java
+++ b/src/main/java/org/libdohj/cate/controller/MainController.java
@@ -29,6 +29,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.ResourceBundle;
 
+import com.sun.deploy.uitoolkit.impl.fx.HostServicesFactory;
+import com.sun.javafx.application.HostServicesDelegate;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
@@ -61,6 +63,8 @@ import java.util.stream.Collectors;
 import javafx.beans.property.StringProperty;
 
 import org.controlsfx.control.NotificationPane;
+import org.libdohj.cate.CATE;
+import org.libdohj.cate.util.BlockExplorerResolver;
 import org.libdohj.cate.util.NetworkResolver;
 import org.spongycastle.crypto.params.KeyParameter;
 
@@ -240,6 +244,19 @@ public class MainController {
 
     private void initializeTransactionList() {
         txList.setItems(transactions);
+        txList.setRowFactory(value ->{
+            final TableRow<WalletTransaction> row = new TableRow<>();
+            final ContextMenu rowMenu = new ContextMenu();
+            final MenuItem explorerItem = new MenuItem(resources.getString("menuItem.showOnExplorer"));
+
+            explorerItem.setOnAction(action -> openBlockExplorer(row.getItem()));
+
+            rowMenu.getItems().add(explorerItem);
+
+            row.contextMenuProperty().set(rowMenu);
+
+            return row;
+        });
         txNetworkColumn.setCellValueFactory(dataFeatures -> {
             final WalletTransaction transaction = dataFeatures.getValue();
             final NetworkParameters params = transaction.getParams();
@@ -258,6 +275,11 @@ public class MainController {
             final WalletTransaction transaction = dataFeatures.getValue();
             return new SimpleStringProperty(transaction.getTransaction().getMemo());
         });
+    }
+
+    private void openBlockExplorer(WalletTransaction item) {
+        HostServicesDelegate hostServices = HostServicesFactory.getInstance(CATE.getInstance());
+        hostServices.showDocument(BlockExplorerResolver.getUrl(item));
     }
 
     private void initializeWalletList() {

--- a/src/main/java/org/libdohj/cate/util/BlockExplorerResolver.java
+++ b/src/main/java/org/libdohj/cate/util/BlockExplorerResolver.java
@@ -1,0 +1,51 @@
+package org.libdohj.cate.util;
+
+import org.libdohj.cate.controller.MainController;
+
+/**
+ * Created by maxke on 13.01.2016.
+ * Finds an URL to call to show a certain transaction on a block explorer website
+ */
+public class BlockExplorerResolver {
+
+    private static final String CHAINSO_BASE_URL = "https://chain.so/";
+    private static final String CHAINSO_PATH_TX = "tx/";
+    private static final String CHAINSO_PATH_BTC = "BTC/";
+    private static final String CHAINSO_PATH_LTC = "LTC/";
+    private static final String CHAINSO_PATH_DOGE = "DOGE/";
+    private static final String CHAINSO_PATH_BTCTEST = "BTCTEST/";
+    private static final String CHAINSO_PATH_LTCTEST = "LTCTEST/";
+    private static final String CHAINSO_PATH_DOGETEST = "DOGETEST/";
+
+    public static String getUrl(MainController.WalletTransaction wtx) {
+        // TODO: This should take into account a setting the user can make for the explorer to use.
+        return getChainSoUrl(wtx);
+    }
+
+    public static String getChainSoUrl(MainController.WalletTransaction wtx) {
+        StringBuilder sb = new StringBuilder(CHAINSO_BASE_URL);
+        sb.append(CHAINSO_PATH_TX);
+        sb.append(networkCodeToPath(NetworkResolver.getCode(wtx.getParams())));
+        sb.append(wtx.getTransaction().getHashAsString());
+        return sb.toString();
+    }
+
+    private static String networkCodeToPath(NetworkResolver.NetworkCode code) {
+        switch (code) {
+            case BTC:
+                return CHAINSO_PATH_BTC;
+            case BTCTEST:
+                return CHAINSO_PATH_BTCTEST;
+            case LTC:
+                return CHAINSO_PATH_LTC;
+            case LTCTEST:
+                return CHAINSO_PATH_LTCTEST;
+            case DOGE:
+                return CHAINSO_PATH_DOGE;
+            case DOGETEST:
+                return CHAINSO_PATH_DOGETEST;
+            default:
+                return "";
+        }
+    }
+}

--- a/src/main/java/org/libdohj/cate/util/NetworkResolver.java
+++ b/src/main/java/org/libdohj/cate/util/NetworkResolver.java
@@ -1,6 +1,5 @@
 package org.libdohj.cate.util;
 
-import java.util.Collection;
 import org.bitcoinj.core.NetworkParameters;
 import org.bitcoinj.params.MainNetParams;
 import org.bitcoinj.params.TestNet3Params;
@@ -19,19 +18,31 @@ public class NetworkResolver {
 
     private static final LinkedHashMap<NetworkParameters, String> networkNames = new LinkedHashMap<>();
     private static final LinkedHashMap<String, NetworkParameters> networksByName = new LinkedHashMap<>();
-    public static ResourceBundle resource;
+    private static final LinkedHashMap<NetworkParameters, NetworkCode> networkCodes = new LinkedHashMap<>();
+    private static final LinkedHashMap<NetworkCode, NetworkParameters> networksByCode = new LinkedHashMap<>();
 
-    static {
-        registerNetwork(MainNetParams.get(), "Bitcoin");
-        registerNetwork(TestNet3Params.get(), "Bitcoin test");
-        registerNetwork(LitecoinMainNetParams.get(), "Litecoin");
-        registerNetwork(DogecoinMainNetParams.get(), "Dogecoin");
-        registerNetwork(DogecoinTestNet3Params.get(), "Dogecoin test");
+    public enum NetworkCode { // This is way more type safe than some String
+        BTC,
+        BTCTEST,
+        LTC,
+        LTCTEST,
+        DOGE,
+        DOGETEST
     }
 
-    private static void registerNetwork(final NetworkParameters params, final String name) {
+    static {
+        registerNetwork(MainNetParams.get(), "Bitcoin", NetworkCode.BTC);
+        registerNetwork(TestNet3Params.get(), "Bitcoin test", NetworkCode.BTCTEST);
+        registerNetwork(LitecoinMainNetParams.get(), "Litecoin", NetworkCode.LTC);
+        registerNetwork(DogecoinMainNetParams.get(), "Dogecoin", NetworkCode.DOGE);
+        registerNetwork(DogecoinTestNet3Params.get(), "Dogecoin test", NetworkCode.DOGETEST);
+    }
+
+    private static void registerNetwork(final NetworkParameters params, final String name, NetworkCode code) {
         networkNames.put(params, name);
         networksByName.put(name, params);
+        networkCodes.put(params, code);
+        networksByCode.put(code, params);
     }
 
     /**
@@ -41,6 +52,14 @@ public class NetworkResolver {
      */
     public static Set<String> getNames() {
         return networksByName.keySet();
+    }
+
+    /**
+     * Get all network codes the resolver knows about.
+     * @return a set of network explicit network codes
+     */
+    public static Set<NetworkCode> getCodes() {
+        return networksByCode.keySet();
     }
 
     /**
@@ -56,7 +75,15 @@ public class NetworkResolver {
         return networkNames.get(params);
     }
 
+    public static NetworkCode getCode(NetworkParameters params) {
+        return networkCodes.get(params);
+    }
+
     public static NetworkParameters getParameter(String name) {
         return networksByName.get(name);
+    }
+
+    public static NetworkParameters getParameter(NetworkCode code) {
+        return networksByCode.get(code);
     }
 }

--- a/src/main/resources/i18n/Bundle.properties
+++ b/src/main/resources/i18n/Bundle.properties
@@ -33,6 +33,7 @@ walletSend.sendButton=Send
 
 menuItem.encrypt=Encrypt Wallet
 menuItem.decrypt=Decrypt Wallet
+menuItem.showOnExplorer=Show on blockchain explorer
 
 buttonType.Ok=Okay
 responseType.False=False

--- a/src/main/resources/i18n/Bundle_de_DE.properties
+++ b/src/main/resources/i18n/Bundle_de_DE.properties
@@ -32,6 +32,7 @@ walletSend.sendButton=Senden
 
 menuItem.encrypt=Wallet verschl\u00fcsseln
 menuItem.decrypt=Wallet entschl\u00fcsseln
+menuItem.showOnExplorer=Auf blockchain explorer anzeigen
 
 buttonType.Ok=Okay
 responseType.False=Falsch

--- a/src/main/resources/main.fxml
+++ b/src/main/resources/main.fxml
@@ -1,14 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.*?>
-<?import javafx.scene.text.*?>
 <?import javafx.scene.control.*?>
-<?import java.lang.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
 
 <BorderPane
     xmlns:fx="http://javafx.com/fxml/1"

--- a/src/test/java/org/libdohj/cate/util/NetworkResolverTest.java
+++ b/src/test/java/org/libdohj/cate/util/NetworkResolverTest.java
@@ -34,6 +34,7 @@ public class NetworkResolverTest {
     public void shouldListNetworks() {
         assertFalse(NetworkResolver.getParameters().isEmpty());
         assertFalse(NetworkResolver.getNames().isEmpty());
+        assertFalse(NetworkResolver.getCodes().isEmpty());
     }
 
     /**
@@ -43,7 +44,9 @@ public class NetworkResolverTest {
     public void shouldMapSymmetrically() {
         for (NetworkParameters params: NetworkResolver.getParameters()) {
             final String name = NetworkResolver.getName(params);
+            final NetworkResolver.NetworkCode code = NetworkResolver.getCode(params);
             assertEquals(params, NetworkResolver.getParameter(name));
+            assertEquals(params, NetworkResolver.getParameter(code));
         }
     }
 }


### PR DESCRIPTION
Adds a resolver to get the URL per tx. Needs a user setting.
Cleans up some imports.

I also added an enum of NetworkCodes to be a bit more type safe there. The static reference to the Application instance seems like the cleanest way to achieve access to it. The Application lives as long as the application is running so it shouldn't cause any issues.
